### PR TITLE
v2.11.0 - Fix optional cols logic 

### DIFF
--- a/resources/home/dnanexus/generate_workbook/tests/test_vcf.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_vcf.py
@@ -251,7 +251,6 @@ class TestDataFrameActions():
             args_obj = object.__new__(arguments)
             args_obj.args = args_obj.parse_args()
 
-        args_obj.args.add_name = True
         args_obj.args.sheets = ['variants']
         args_obj.args.vcfs = [self.columns_vcf]
         vcf_handler = vcf(args_obj.args)

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -763,29 +763,29 @@ class vcf():
                     for col in invalid:
                         to_drop.remove(col)
 
+            # Preserve dynamically added columns from being dropped
+            columns_to_preserve = []
             if self.args.add_name:
-                to_drop.remove("sampleName")
-
+                columns_to_preserve.append("sampleName")
             if self.args.add_comment_column:
-                to_drop.remove("Comment")
-
+                columns_to_preserve.append("Comment")
             if self.args.add_classification_column:
-                to_drop.remove("Classification")
-
+                columns_to_preserve.append("Classification")
             if self.args.add_allele_origin_column:
-                to_drop.remove("Allele_Origin")
-
+                columns_to_preserve.append("Allele_Origin")
             if self.args.add_interpreted_column:
-                to_drop.remove("Interpreted")
-
+                columns_to_preserve.append("Interpreted")
             if self.args.add_reported_column:
-                to_drop.remove("Reported")
-
+                columns_to_preserve.append("Reported")
             if self.args.add_mnv_column:
-                to_drop.remove("MNV")
-
+                columns_to_preserve.append("MNV")
             if self.args.add_report_text_column:
-                to_drop.remove("Report_text")
+                columns_to_preserve.append("Report_text")
+
+            # Remove preserved columns from to_drop list
+            to_drop = [
+                col for col in to_drop if col not in columns_to_preserve
+            ]
 
             vcfs[idx].drop(to_drop, axis=1, inplace=True, errors='ignore')
 

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -763,6 +763,9 @@ class vcf():
                     for col in invalid:
                         to_drop.remove(col)
 
+            if self.args.add_name:
+                to_drop.remove("sampleName")
+
             if self.args.add_comment_column:
                 to_drop.remove("Comment")
 

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -763,6 +763,27 @@ class vcf():
                     for col in invalid:
                         to_drop.remove(col)
 
+            if self.args.add_comment_column:
+                to_drop.remove("Comment")
+
+            if self.args.add_classification_column:
+                to_drop.remove("Classification")
+
+            if self.args.add_allele_origin_column:
+                to_drop.remove("Allele_Origin")
+
+            if self.args.add_interpreted_column:
+                to_drop.remove("Interpreted")
+
+            if self.args.add_reported_column:
+                to_drop.remove("Reported")
+
+            if self.args.add_mnv_column:
+                to_drop.remove("MNV")
+
+            if self.args.add_report_text_column:
+                to_drop.remove("Report_text")
+
             vcfs[idx].drop(to_drop, axis=1, inplace=True, errors='ignore')
 
 


### PR DESCRIPTION
If specifying --add_x_column flags, fix so that you no longer have to specify these columns in --include_columns list to be included in the workbook. Also, ignore if these columns are specified in --exclude_columns.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/228)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that dynamically added columns such as "sampleName", "Comment", "Classification", "Allele_Origin", "Interpreted", "Reported", "MNV", and "Report_text" are retained when applying column filtering options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->