### PR TITLE
v2.11.0 -  Change M-codes input from str to file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -120,7 +120,7 @@ This app may be executed as a standalone app.
 
 `--add_auto_filter` (`bool`): If true, an excel auto-filter is added to variant sheets. This is useful if you are specifying `--lock_sheet`, as an auto-filter cannot be added manually to a locked excel sheet.
 
-`--sort_by` (`string`): Names of VCF columns to sort by, and corresponding boolean for whether to sort in ascending order or not, with the column name and its corresponding boolean joined by a colon (:), and each column name:boolean pair separated by a space. For e.g. `--sort_vars_by="CSQ_SYMBOL:True CHROM:True POS:True"`. Note: sorting occurs before column renaming but after the splitting out of the VCF INFO fields. Therefore you must specify the original column names.
+`--sort_by` (`string`): Names of VCF columns to sort by, and corresponding boolean for whether to sort in ascending order or not, with the column name and its corresponding boolean joined by a colon (:), and each column name:boolean pair separated by a space. For e.g. `--sort_by="CSQ_SYMBOL:True CHROM:True POS:True"`. Note: sorting occurs before column renaming but after the splitting out of the VCF INFO fields. Therefore you must specify the original column names.
 
 **Example**:
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -336,10 +336,10 @@
     },
     {
       "name": "m_codes",
-      "label": "File ID for M-codes file",
+      "label": "M-codes file containing all valid M-codes",
       "class": "file",
       "optional" : true,
-      "help": "DNAnexus file ID for file containing all valid M-codes. M-codes should be provided one per line in a .txt file."
+      "help": "DNAnexus file containing all valid M-codes. M-codes should be provided one per line in a .txt file."
     },
     {
       "name": "add_auto_filter",

--- a/dxapp.json
+++ b/dxapp.json
@@ -337,7 +337,7 @@
     {
       "name": "m_codes",
       "label": "File ID for M-codes file",
-      "class": "string",
+      "class": "file",
       "optional" : true,
       "help": "DNAnexus file ID for file containing all valid M-codes. M-codes should be provided one per line in a .txt file."
     },

--- a/resources/home/dnanexus/generate_workbook/generate_workbook.py
+++ b/resources/home/dnanexus/generate_workbook/generate_workbook.py
@@ -63,26 +63,6 @@ class arguments():
         def __call__(self, parser, namespace, values, option_string=None):
             setattr(namespace, self.dest, ' '.join(values))
 
-    def dx_file_id(self, value: str) -> str:
-        """
-        Validate DNAnexus file ID format: must start with 'file-' followed by
-        a 24 character alphanumeric.
-
-        Returns
-        -------
-        value : str
-            Inputted value is returned if it is a valid DNAnexus file ID.
-        Raises
-        ------
-        argparse.ArgumentTypeError
-            Raised when invalid file ID is passed.
-        """
-        if not re.match(r'^file-[A-Za-z0-9]{24}$', value):
-            raise argparse.ArgumentTypeError(
-                f"Invalid DNAnexus file ID: {value!r}"
-            )
-        return value
-
     def parse_args(self) -> argparse.Namespace:
         """
         Parse command line arguments
@@ -370,10 +350,10 @@ class arguments():
             )
         )
         parser.add_argument(
-            '--m_codes', required=False, type=self.dx_file_id,
+            '--m_codes', required=False,
             help=(
-                'DNAnexus file-ID for file containing a list of valid M-codes.'
-                ' M-codes should be provided one per line in a .txt file.'
+                'File containing a list of valid M-codes. M-codes should be '
+                'provided one per line in a .txt file.'
             )
         )
         parser.add_argument(

--- a/resources/home/dnanexus/generate_workbook/tests/test_excel.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_excel.py
@@ -156,46 +156,41 @@ class TestStoreListInSheet:
         assert ws["A2"].value == "Gimme Gimme Gimme"
         assert ws["A3"].value == "Lay All Of Your Love On Me"
 
+
 class TestReadMCodesFile:
     """
     Collection of test cases for utils.excel.excel.read_m_codes_file
     """
-    def test_success_upon_compliant_mcodes(self, mocked_excel_file, monkeypatch):
+
+    def test_success_upon_compliant_mcodes(self, tmp_path):
         """
-        Test that a file containing m-codes that conform to the regex specification
-        are read without throwing an error when read by utils.excel.excel.read_m_codes_file
+        Test that a file containing m-codes that conform to the regex
+        specification are read without throwing an error when read by
+        utils.excel.excel.read_m_codes_file
         """
-        class CompliantMFile:
-            def __init__(self):
-                pass
 
-            def read(self):
-                return "M123"
+        compliant_content = "M1\nM2\nM3\n"
+        file_path = tmp_path / "compliant_mcodes.txt"
+        file_path.write_text(compliant_content, encoding="utf-8")
 
-        def return_compliant_file(*args, **kwargs):
-            return CompliantMFile() 
+        result = excel.read_m_codes_file(file_path)
 
-        monkeypatch.setattr("utils.excel.open_dxfile", return_compliant_file)
-        mocked_excel_file.read_m_codes_file()
+        assert result == ["M1", "M2", "M3"]
 
-    def test_exception_upon_noncompliant_mcodes(self, mocked_excel_file, monkeypatch):
+    def test_exception_upon_noncompliant_mcodes(self, tmp_path):
         """
-        Test that a file containing m-codes that do not conform to the regex specification
-        cause a `ValueError` to be thrown when it is read by utils.excel.excel.read_m_codes_file
+        Test that a file containing m-codes that do not conform to the regex
+        specification cause a `ValueError` to be thrown when it is read by
+        utils.excel.excel.read_m_codes_file
         """
-        class NonCompliantMFile:
-            def __init__(self):
-                pass
+        noncompliant_content = "hi\nthis\nshouldnt\nwork\n"
+        file_path = tmp_path / "noncompliant_mcodes.txt"
+        file_path.write_text(noncompliant_content, encoding="utf-8")
 
-            def read(self):
-                return "hi\nthis\nshouldnt\nwork"
+        with pytest.raises(ValueError,
+                           match=r".*M-codes file not formatted correctly.*"):
+            excel.read_m_codes_file(file_path)
 
-        def return_noncompliant_file(*args, **kwargs):
-            return NonCompliantMFile() 
-
-        monkeypatch.setattr("utils.excel.open_dxfile", return_noncompliant_file)
-        with pytest.raises(ValueError, match=r".*M-codes file not formatted correctly.*"):
-            mocked_excel_file.read_m_codes_file()
 
 class TestStrToDropdown:
     """

--- a/resources/home/dnanexus/generate_workbook/tests/test_generate_workbook.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_generate_workbook.py
@@ -107,42 +107,6 @@ class TestVerifyColours():
             self.args_obj.verify_colours()
 
 
-class TestDxFileID():
-    """
-    Tests for the generate_workbook.dx_file_id method.
-    Ensures that a DNAnexus file ID is correctly formatted and parsed.
-    """
-
-    @pytest.fixture
-    def args_obj(self):
-        """
-        Provides a fresh arguments object for each test.
-        """
-        return object.__new__(arguments)
-
-    @pytest.mark.parametrize(
-        "dx_id",
-        ["notafileid", "file-J0527G8487XjKgKJXjYqbgP",
-         "file-J0527G8487XjKgKJXjYqbgPFX1",
-         "file-J0527G8487XjKgKJXjYqbgPFfile-J0527G8487XjKgKJXjYqbgPF"]
-    )
-    def test_invalid_dx_file_id_raises_correct_error(self, args_obj, dx_id):
-        """
-        Tests the correct error is raised when invalid DNAnexus file IDs are
-        passed to dx_file_id()
-        """
-        expected = "Invalid DNAnexus file ID:"
-        with pytest.raises(argparse.ArgumentTypeError, match=expected):
-            args_obj.dx_file_id(dx_id)
-
-    def test_valid_dx_file_id_is_returned(self, args_obj):
-        """
-        Test valid DNAnexus file IDs are returned successsfully by dx_file_id()
-        """
-        valid_dx_id = "file-J0527G8487XjKgKJXjYqbgPF"
-        assert args_obj.dx_file_id(valid_dx_id) == "file-J0527G8487XjKgKJXjYqbgPF"
-
-
 class TestVerifySortBy():
     """
     Tests for the generate_workbook.verify_sort_by method.

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -20,7 +20,6 @@ from openpyxl.utils import get_column_letter as col_idx_to_col_letter
 from openpyxl.worksheet.datavalidation import DataValidation
 from openpyxl.styles.protection import Protection
 import pandas as pd
-from dxpy.bindings.dxfile_functions import open_dxfile
 
 from .utils import is_numeric
 
@@ -300,7 +299,7 @@ class excel():
             cell_for_drop_down = "B6"
 
             self.list_to_drop_down(
-                dropdown_options=self.read_m_codes_file(),
+                dropdown_options=self.read_m_codes_file(self.args.m_codes),
                 dropdown_options_sheet_name="m_codes",
                 dropdown_options_col="A",
                 prompt="M-code associated with sample",
@@ -2286,28 +2285,29 @@ class excel():
                 cells=cells
         )
 
-    def read_m_codes_file(self) -> list:
+    @staticmethod
+    def read_m_codes_file(file) -> list:
         """
-        Reads in M-codes file from DNAnexus and checks that file is formatted
+        Reads in M-codes file and checks that file is formatted
         correctly.
 
         Raises:
             ValueError: if line found in M-codes file which does not contain a
-            single valid M-code.
+            singlular valid M-code.
 
         Returns:
             List containing M-codes stripped of any leading/trailing
             whitespace
         """
-        lines = [
-            line.strip() for line in open_dxfile(
-                self.args.m_codes, mode="r").read().splitlines()
-        ]
+        with open(file, 'r', encoding="UTF-8") as f:
+            lines = []
+            for idx, line in enumerate(f, 1):
+                stripped = line.strip()
+                if not re.match(r'^M\d+$', stripped):
+                    raise ValueError(
+                        f"M-codes file not formatted correctly. Incorrect "
+                        f"value {repr(line)} found in line {idx}"
+                    )
+                lines.append(stripped)
 
-        for idx, line in enumerate(lines, 1):
-            if not re.match(r'^M\d+$', line):
-                raise ValueError(
-                    f"M-codes file not formatted correctly. Incorrect value "
-                    f"{repr(line)} found in line {idx}"
-                )
         return lines

--- a/src/code.sh
+++ b/src/code.sh
@@ -116,9 +116,10 @@ main() {
     if [ "$lock_sheet" == true ]; then args+="--lock_sheet "; fi
     if [ "$af_format" ]; then args+="--af_format ${af_format} "; fi
     if [ "$join_columns" ]; then args+="--join_columns ${join_columns} "; fi
-    if [ "$m_codes" ]; then args+="--m_codes ${m_codes} "; fi
+    if [ "$m_codes" ]; then args+="--m_codes in/m_codes/* "; fi
     if [ "$add_auto_filter" ]; then args+="--add_auto_filter "; fi
     if [ "$sort_by" ]; then args+="--sort_by ${sort_by} "; fi
+
 
     args+="--out_dir /home/dnanexus/out/xlsx_reports "
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/231)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected the documentation for the --sort_by parameter example to use the correct flag name.
* **New Features**
  * Updated the input specification for "m_codes" to expect a file input rather than a string.
* **Bug Fixes**
  * Improved validation and error reporting for M-code files, now providing line numbers for invalid entries.
* **Refactor**
  * Replaced DNAnexus-specific file reading with standard file handling for M-code files.
  * Updated method signatures and internal logic to simplify file input processing.
* **Tests**
  * Removed tests related to DNAnexus file ID validation for M-codes, reflecting the new file-based approach.
  * Refactored tests for M-code file reading to use actual temporary files instead of mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->