### PR TITLE
DI-3127 - fix zip() bug

### DIFF
--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -599,7 +599,7 @@ class excel():
         row_count = 9
 
         # write counts of variants
-        for sheet, vcf in zip(self.args.sheets, self.vcfs, strict=True):
+        for sheet, vcf in zip(self.args.sheets, self.vcfs):
             self.summary.cell(row_count, 2).value = sheet
             self.summary.cell(row_count, 3).value = len(vcf.index)
             to_bold.append(f"B{row_count}")


### PR DESCRIPTION
Remove strict=True from zip() calls for Python <3.10 compatibility. Other summary sheets do not use strict=True, therefore this was incorrectly introduced.

Example job: https://platform.dnanexus.com/panx/projects/J9V284Q42Q966GY6102F1xpV/monitor/job/J9j758042Q90FPjQPJyx7X3b

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/244)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workbook generation when the configured sheets and variant files have different lengths.
  * Prevented unnecessary failures during Atlas summary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->